### PR TITLE
Add MLP script with command-line options and configure entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__
-Digraph.gv
-Digraph.gv.pdf
+Computational_graph
+Computational_graph.*

--- a/micrograd/backpropagation.py
+++ b/micrograd/backpropagation.py
@@ -124,7 +124,7 @@ class Value:
         for v in reversed(topo):
             v._backward()
 
-    def print_graph(self):
+    def print_graph(self, filename="Computational_graph", directory=".", format="pdf"):
         dot = graphviz.Digraph(
             comment="Computational Graph", graph_attr={"rankdir": "LR"}
         )
@@ -150,6 +150,10 @@ class Value:
                         dot.edge(f"{child_id}", f"{node_id}")
 
         bfs(root)
+        output_path = dot.render(
+            filename=filename, directory=directory, format=format, cleanup=True
+        )
+        print(f"Graph saved to: {output_path}")
         dot.view()
 
     def __repr__(self):

--- a/micrograd/build_graph.py
+++ b/micrograd/build_graph.py
@@ -10,9 +10,11 @@ def main():
     parser.add_argument(
         "--save_dir", "-s", type=str, help="Directory to save the Computational Graph"
     )
-    parser.add_argument("--input", "-i", nargs="+", type=int, help="Input of the MLP")
     parser.add_argument(
-        "--output", "-o", nargs="+", type=int, help="A list of neurons output"
+        "--input", "-i", required=True, nargs="+", type=int, help="Input of the MLP"
+    )
+    parser.add_argument(
+        "--output", "-o", required=True, nargs="+", type=int, help="A list of neurons output"
     )
     parser.add_argument(
         "--activation",

--- a/micrograd/build_graph.py
+++ b/micrograd/build_graph.py
@@ -1,0 +1,35 @@
+import argparse
+
+from micrograd.neural_network import MLP
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build a computational graph and apply backpropoagation to an MLP"
+    )
+    parser.add_argument(
+        "--save_dir", "-s", type=str, help="Directory to save the Computational Graph"
+    )
+    parser.add_argument("--input", "-i", nargs="+", type=int, help="Input of the MLP")
+    parser.add_argument(
+        "--output", "-o", nargs="+", type=int, help="A list of neurons output"
+    )
+    parser.add_argument(
+        "--activation",
+        "-a",
+        type=str,
+        default="relu",
+        help="Activation function to use for each layer of the MLP: 'relu' or 'tanh' (default: 'relu')",
+    )
+    args = parser.parse_args()
+    if args.activation not in ("relu", "tanh"):
+        parser.error(f"Unsupported activation function: {args.activation}")
+    x = args.input
+    n = MLP(len(x), args.output, activation=args.activation)
+    output = n(x)
+    output.backward()
+    output.print_graph(directory=args.save_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/micrograd/neural_network.py
+++ b/micrograd/neural_network.py
@@ -4,7 +4,7 @@ from micrograd.backpropagation import Value
 
 
 class Neuron:
-    def __init__(self, nin):
+    def __init__(self, nin, activation="relu"):
         self.weights = []
         for i in range(nin):
             weight = Value(random.uniform(-1, 1))
@@ -12,16 +12,20 @@ class Neuron:
             self.weights.append(weight)
         self.bias = Value(random.uniform(-1, 1))
         self.bias.label = f"bias with id {id(self.bias)}"
+        self.activation = activation
 
     def __call__(self, x):
         output = sum((wi * xi for wi, xi in zip(self.weights, x)), self.bias)
-        output = output.tanh()
+        if self.activation == "relu":
+            output = output.relu()
+        elif self.activation == "tanh":
+            output = output.tanh()
         return output
 
 
 class Layer:
-    def __init__(self, nin, nout):
-        self.neurons = [Neuron(nin) for _ in range(nout)]
+    def __init__(self, nin, nout, activation="relu"):
+        self.neurons = [Neuron(nin, activation=activation) for _ in range(nout)]
 
     def __call__(self, x):
         output = [n(x) for n in self.neurons]
@@ -29,9 +33,12 @@ class Layer:
 
 
 class MLP:
-    def __init__(self, nin, nouts):
+    def __init__(self, nin, nouts, activation="relu"):
         in_outs = [nin] + nouts
-        self.layers = [Layer(in_outs[i], in_outs[i + 1]) for i in range(len(nouts))]
+        self.layers = [
+            Layer(in_outs[i], in_outs[i + 1], activation=activation)
+            for i in range(len(nouts))
+        ]
 
     def __call__(self, x):
         for layer in self.layers:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,5 @@ universal = true
 requires = [
 	"setuptools==69.5.1",
 	"wheel",
-
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ where = ["."]
 exclude = ["tests"]
 namespaces = false
 
+[project.scripts]
+micrograd = "micrograd.build_graph:main"
+
 [project.optional-dependencies]
 test = [
 	"coverage>=5.0.2",


### PR DESCRIPTION
This pull request introduces a new script for handling Multi-Layer Perceptron (MLP) operations with command-line options. It also updates `pyproject.toml` to register the script as an executable command.
## Changes
- Add micrograd/build_graph.py which is the MLP script  with command-line options
- Update `pyproject.toml` to configure the command `micrograd`  which points to the new's script `main` function.
## Reason
The addition of this script provides a convenient way to build and visualise computational graphs for MLPs directly from the command line. Configuring the entry point in `pyproject.toml` allows users to easily execute the script after installation.
