### PR TITLE
Add GitHub Action for publishing Python packages to PyPI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: publish
+on:
+  push:
+    tags:
+     - 'v*'
+
+jobs:
+  publish-tag:
+    name: Build and publish Python distributions to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build source and wheel distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          twine check dist/*
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -32,6 +32,3 @@ jobs:
               run: tox -c tox.ini -e check-formatting,lint
             - name: Run Test Suite
               run: tox -c tox.ini -e py312
-
-
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "micrograd"
 version = "1.0.0"
-description = "Backprogation from scratch"
+description = "Backpropagation from scratch"
 keywords = []
 classifiers = [
 	"Development Status :: 5 - Production/Stable",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "micrograd"
-version = "0.0.1"
+version = "1.0.0"
 description = "Backprogation from scratch"
 keywords = []
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ author_email = "xelithras94@gmail.com"
 maintainer = "Lorenzo Del Signore"
 maintainer_email = "xelithras94@gmail.com"
 url = "https://github.com/lorenzo-delsignore/micrograd"
-long_description = "Backprogation from scratch"
+long_description = { file = "README.md" }
+long_description_content_type = "text/markdown"
 license = { file = "LICENSE" }
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,4 +62,3 @@ requires = [
 	"setuptools==69.5.1",
 	"wheel",
 ]
-


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow (publish.yml) that automates the process of building and publishing `micrograd` package to PyPI. The workflow is triggered whenever a new Git tag that starts with v (e.g., v1.0.0) is pushed to the repository.